### PR TITLE
Expose WebPConfig conversion

### DIFF
--- a/Sources/webp/WebPEncoderConfig.swift
+++ b/Sources/webp/WebPEncoderConfig.swift
@@ -137,7 +137,7 @@ public struct WebpEncoderConfig: InternalRawRepresentable {
         return WebpEncoderConfig(rawValue: webPConfig)!
     }
 
-    internal init?(rawValue: WebPConfig) {
+    public init?(rawValue: WebPConfig) {
         lossless = Int(rawValue.lossless)
         quality = rawValue.quality
         method = Int(rawValue.method)
@@ -169,7 +169,7 @@ public struct WebpEncoderConfig: InternalRawRepresentable {
         qmax = Int(rawValue.qmax)
     }
 
-    internal var rawValue: WebPConfig {
+    public var rawValue: WebPConfig {
         let show_compressed = showCompressed ? Int32(1) : Int32(0)
         let emulate_jpeg_size = emulateJpegSize ? Int32(1) : Int32(0)
         let low_memory = lowMemory ? Int32(1) : Int32(0)


### PR DESCRIPTION
I'm implementing an encoding function that takes a YUV 4:2:0 pixel buffer and directly provides the data to the WebP encoder.
This is relevant because ARKit/CoreVideo buffers form iPhone/iPad cameras provide YUV 4:2:0 Bi-Planar data natively and I don't want the overhead of converting the buffers to RGB/BGR.

To achieve that I've implemented the encoding function analogous to your implementation in [`WebPEncoder.swift:88`](https://github.com/awxkee/webp.swift/blob/9c215936bb2ad17a6846544290d346853ada1390/Sources/webp/WebPEncoder.swift#L88).

```swift
/// Encode a YUV 4:2:0 bi-planar pixel buffer as WebP YUV 4:2:0 image.
/// - Parameters:
///   - imageBuffer: CVImageBuffer in YUV 4:2:0 bi-planar  format.
///   - config: WebP encoder configuration.
/// - Returns: Encoded WebP Data.
///
/// <https://developer.apple.com/documentation/accelerate/conversion/understanding_ypcbcr_image_formats>
static func encode(YUV420BiPlanar imageBuffer: CVImageBuffer, config: WebpEncoderConfig, scale: Double = 1.0) throws -> Data {
    // Lock the pixel buffer base address access (read only is fine).
    CVPixelBufferLockBaseAddress(imageBuffer, .readOnly)
    defer { CVPixelBufferUnlockBaseAddress(imageBuffer, .readOnly) }

    // Get the luma plane (Y') and its resolution and stride.
    let lumaPlaneIdx = 0
    guard let yBaseAddress = CVPixelBufferGetBaseAddressOfPlane(imageBuffer, lumaPlaneIdx) else {
        throw Error.failedToGetBaseAddressForPlane(lumaPlaneIdx)
    }
    let yWidth = CVPixelBufferGetWidthOfPlane(imageBuffer, lumaPlaneIdx)
    let yHeight = CVPixelBufferGetHeightOfPlane(imageBuffer, lumaPlaneIdx)
    let yStride = CVPixelBufferGetBytesPerRowOfPlane(imageBuffer, lumaPlaneIdx)

    // get the interleaved chroma plane (CbCr).
    let chromaPlaneIdx = 1
    guard let uvBaseAddress = (CVPixelBufferGetBaseAddressOfPlane(imageBuffer, chromaPlaneIdx)) else {
        throw Error.failedToGetBaseAddressForPlane(chromaPlaneIdx)
    }

    // Setup the webP internal coder configuration struct.
    var config: WebPConfig = config.rawValue
    if WebPValidateConfig(&config) == 0 {
        throw WebPEncoderError.invalidParameter
    }
   
   // ...
}
```

This works great however to achieve it I've got to access the `config.rawValue` property that assembles the `WebPConfig` struct from the `WebpEncodingConfig` struct.
In the current library version this is a **private** property. 

This PR exposes the initializer and the `rawValue` computed property to the public API.